### PR TITLE
Fix volume and power button lock on Power+VolUp

### DIFF
--- a/event_listener.c
+++ b/event_listener.c
@@ -51,18 +51,6 @@ static int event0 = -1, jevent0 = -1, uinput = -1;
 static bool grabbed, power_button_pressed;
 static int epollfd = -1;
 
-static void enable_joystick(void)
-{
-	ioctl(fileno(jevent0), EVIOCGRAB, false);
-	fcntl(fileno(event0), F_SETFL, 0);
-}
-
-static void disable_joystick(void)
-{
-	ioctl(fileno(jevent0), EVIOCGRAB, true);
-	fcntl(fileno(event0), F_SETFL, O_NONBLOCK);
-}
-
 static void switchmode(enum _mode new)
 {
 
@@ -174,13 +162,11 @@ static void execute(enum event_type event, int value)
 			str = "brightup";
 			blank(0);
 			bright_up(value);
-			enable_joystick();
 			break;
 		case brightdown:
 			str = "brightdown";
 			if (get_brightness() <= 1) {
 				blank(1);
-				disable_joystick();
 			} else {
 				bright_down(value);
 			}


### PR DESCRIPTION
There is a bug on fw 1.7 where the removed function enable_joypad() is now locking the power and volume buttons until a console restart. 
This is an unexpected behaviour, since it was working on fw 1.5.
This change will avoid to try to lock the joypad input and it will just disable the screen at the minimum brightness.